### PR TITLE
Correct idle_timeout setting

### DIFF
--- a/includes/rclone/rclone-template.conf
+++ b/includes/rclone/rclone-template.conf
@@ -3,4 +3,5 @@ type = smb
 host = REMOTE-HOST-PLACEHOLDER
 user = REMOTE-USER-PLACEHOLDER
 pass = REMOTE-PASSWORD-HASHED-PLACEHOLDER
-idle_timeout = 0s
+idle_timeout = 0
+


### PR DESCRIPTION
RClone specifies `0` not `0s` to disable timeouts